### PR TITLE
Pin nixpkgs to latest `20.09` release

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,5 @@
 { pkgs ? import (fetchTarball "github.com/nixos/nixpkgs/archive/d90df566caff6ef84f7bfccc2a2c95496f221d62.tar.gz") {}}:
+# Pinned to the latest (as of this writing) release of NixOS 20.09
 
 pkgs.mkShell {
   name="visr-dev-environment";

--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,10 @@
-{ pkgs ? import <nixpkgs> {}}:
+{ pkgs ? import (fetchTarball "github.com/nixos/nixpkgs/archive/d90df566caff6ef84f7bfccc2a2c95496f221d62.tar.gz") {}}:
 
 pkgs.mkShell {
   name="visr-dev-environment";
-  buildInputs = [
-    pkgs.clojure
-    pkgs.nodejs
+  buildInputs = with pkgs; [
+    clojure
+    nodejs
   ];
   shellHook = ''
     npm ci


### PR DESCRIPTION
This is a super small thing, but typically Nix uses a $NIX_PATH environment variable (during `import <nixpkgs>`) to determine what specific package revision to fetch packages for. 
Explicitly fetching a nixpkgs commit (with `fetchTarball`) rather than relying on the user's global installation to determine the package set ensures that every user gets exactly the same version of `clojure` and `nodejs`.

This may go without saying but this causes no functional change.